### PR TITLE
Avoid some race conditions about arcades

### DIFF
--- a/src/Server/Connection.cpp
+++ b/src/Server/Connection.cpp
@@ -376,9 +376,7 @@ bool Connection::_handlePacket(const Lobbies::PacketGameRequest &packet, size_t 
 	if (size < sizeof(packet))
 		return false;
 	size -= sizeof(packet);
-	this->_machineId = packet.consoleId;
-	if (this->onGameRequest())
-		this->_battleStatus = 1;
+	this->onGameRequest(packet.consoleId);
 	return true;
 }
 
@@ -440,8 +438,6 @@ bool Connection::_handlePacket(const Lobbies::PacketArcadeLeave &packet, size_t 
 		return false;
 	size -= sizeof(packet);
 	this->onArcadeLeave();
-	this->_battleStatus = 0;
-	this->_machineId = 0;
 	return true;
 }
 

--- a/src/Server/Connection.hpp
+++ b/src/Server/Connection.hpp
@@ -72,7 +72,7 @@ public:
 	std::function<void (uint8_t channel, const std::string &msg)> onMessage;
 	std::function<void (const Lobbies::PacketSettingsUpdate &settings)> onSettingsUpdate;
 	std::function<void (const Room &port)> onGameStart;
-	std::function<bool ()> onGameRequest;
+	std::function<bool (uint32_t aid)> onGameRequest;
 	std::function<void ()> onArcadeLeave;
 
 	Connection(std::unique_ptr<sf::TcpSocket> &socket, const char *password);

--- a/src/Server/Server.hpp
+++ b/src/Server/Server.hpp
@@ -39,7 +39,7 @@ private:
 	bool _startRoom(std::vector<Connection *> &machine);
 	void _registerToMainServer();
 	std::vector<std::string> _parseCommand(const std::string &msg);
-	bool _onPlayerJoinArcade(Connection &connection, unsigned id);
+	bool _onPlayerJoinArcade(Connection &connection, unsigned id, bool force = false);
 
 	static void sendSystemMessageTo(Connection *recipient, const std::string &msg, unsigned color);
 

--- a/src/Server/Server.hpp
+++ b/src/Server/Server.hpp
@@ -40,6 +40,7 @@ private:
 	void _registerToMainServer();
 	std::vector<std::string> _parseCommand(const std::string &msg);
 	bool _onPlayerJoinArcade(Connection &connection, unsigned id, bool force = false);
+	void _leaveArcade(Connection &connection);
 
 	static void sendSystemMessageTo(Connection *recipient, const std::string &msg, unsigned color);
 


### PR DESCRIPTION
In this PR, the server will
- modify `connection._battleStatus` and `connection._machineId` only when `_machinesMutex` is locked.
- if a connection has joined an arcade, make the connection leave this arcade before joining a new arcade.