### PR TITLE
Avoid some race conditions

### DIFF
--- a/src/SokuMod/Connection.hpp
+++ b/src/SokuMod/Connection.hpp
@@ -31,6 +31,7 @@ public:
 private:
 	mutable std::mutex _messagesMutex;
 	mutable std::mutex _playerMutex;
+	std::mutex _infoMutex;
 	std::thread _netThread;
 	std::thread _posThread;
 	bool _connected = true;
@@ -80,6 +81,7 @@ public:
 	std::function<unsigned short ()> onHostRequest;
 	std::function<void ()> onDisconnect;
 	std::mutex meMutex;
+	std::mutex functionMutex;
 
 	Connection(const std::string &host, unsigned short port, const Player &initParams);
 	~Connection();
@@ -91,7 +93,7 @@ public:
 	void send(const void *packet, size_t size);
 	bool isInit() const;
 	bool isConnected() const;
-	const LobbyInfo &getLobbyInfo() const;
+	const LobbyInfo getLobbyInfo() const;
 	Player *getMe();
 	const Player *getMe() const;
 	std::vector<Player> getPlayers() const;

--- a/src/SokuMod/InLobbyMenu.cpp
+++ b/src/SokuMod/InLobbyMenu.cpp
@@ -309,14 +309,15 @@ InLobbyMenu::InLobbyMenu(LobbyMenu *menu, SokuLib::MenuConnect *parent, std::sha
 		this->_textSprite[0].rect.height
 	}.to<unsigned>());
 	this->_textSprite[0].setPosition({CURSOR_STARTX - (*(int *)0x411c64 == 1) * 2, CURSOR_STARTY});
+	for (int i = ' '; i < 0x100; i++)
+		this->_getTextSize(i);
+	std::lock_guard<std::mutex> functionMutexGuard(this->_connection->functionMutex);
 	this->onConnectRequest = this->_connection->onConnectRequest;
 	this->onError = this->_connection->onError;
 	this->onImpMsg = this->_connection->onImpMsg;
 	this->onMsg = this->_connection->onMsg;
 	this->onHostRequest = this->_connection->onHostRequest;
 	this->onConnect = this->_connection->onConnect;
-	for (int i = ' '; i < 0x100; i++)
-		this->_getTextSize(i);
 	this->_connection->onDisconnect = [this]{
 		this->_disconnected = true;
 	};
@@ -528,7 +529,9 @@ void InLobbyMenu::_()
 	*(*(char **)0x89a390 + 20) = false;
 	this->_parent->choice = 0;
 	this->_parent->subchoice = 0;
+	this->_connection->meMutex.lock();
 	this->_connection->getMe()->battleStatus = 0;
+	this->_connection->meMutex.unlock();
 	messageBox->active = false;
 }
 
@@ -538,14 +541,16 @@ int InLobbyMenu::onProcess()
 		return false;
 	try {
 		this->_menu->execUiCallbacks();
-		if (!this->_connection->isInit() && !this->_wasConnected) {
-			this->_loadingGear.setRotation(this->_loadingGear.getRotation() + 0.1);
-			return this->_connection->isConnected();
+		std::unique_lock<std::mutex> meMutexLock(this->_connection->meMutex);
+		if (!this->_connection->isInit()) {
+			if (!this->_wasConnected) {
+				this->_loadingGear.setRotation(this->_loadingGear.getRotation() + 0.1);
+				return this->_connection->isConnected();
+			}
+			else
+				return false;
 		}
-		if (!this->_connection->isInit())
-			return false;
 
-		this->_connection->meMutex.lock();
 		auto inputs = SokuLib::inputMgrs.input;
 		auto me = this->_connection->getMe();
 
@@ -564,7 +569,6 @@ int InLobbyMenu::onProcess()
 			this->_hostlist.reset();
 			this->_currentMachine = nullptr;
 			playSound(0x29);
-			this->_connection->meMutex.unlock();
 			return true;
 		}
 		this->updateChat(false);
@@ -589,8 +593,7 @@ int InLobbyMenu::onProcess()
 		if (SokuLib::checkKeyOneshot(DIK_ESCAPE, 0, 0, 0)) {
 			playSound(0x29);
 			if (!this->_editingText) {
-
-				this->_connection->meMutex.unlock();
+				meMutexLock.unlock();
 				this->_unhook();
 				this->_connection->disconnect();
 				if (this->_parent->choice == SokuLib::MenuConnect::CHOICE_HOST) {
@@ -774,7 +777,7 @@ int InLobbyMenu::onProcess()
 
 				if (SokuLib::inputMgrs.input.horizontalAxis < 0 && me->pos.x < PLAYER_H_SPEED) {
 					playSound(0x29);
-					this->_connection->meMutex.unlock();
+					meMutexLock.unlock();
 					this->_connection->disconnect();
 					return false;
 				}
@@ -896,7 +899,7 @@ int InLobbyMenu::onProcess()
 		}
 
 		this->_connection->updatePlayers(lobbyData->avatars);
-		if (!this->_translateAnimation) {
+		if (this->_connection->isInit() && !this->_translateAnimation) {
 			if (me->pos.x < 320)
 				this->_translate.x = 0;
 			else if (me->pos.x > bg.size.x - 320)
@@ -905,7 +908,7 @@ int InLobbyMenu::onProcess()
 				this->_translate.x = 320 - me->pos.x;
 			this->_translate.y = 340 - me->pos.y;
 		}
-		this->_connection->meMutex.unlock();
+		this->_playersCopy = this->_connection->getPlayers();
 		return true;
 	} catch (std::exception &e) {
 		MessageBoxA(
@@ -942,7 +945,7 @@ int InLobbyMenu::onRender()
 		}
 
 		auto &bg = lobbyData->backgrounds[this->_background];
-		auto players = this->_connection->getPlayers();
+
 		SokuLib::DrawUtils::RectangleShape rect2;
 #ifdef _DEBUG
 		SokuLib::DrawUtils::RectangleShape rect;
@@ -952,7 +955,6 @@ int InLobbyMenu::onRender()
 #endif
 		rect2.setBorderColor(SokuLib::Color::Black);
 		rect2.setFillColor(SokuLib::Color{0x00, 0x00, 0x00, 0xA0});
-
 		for (auto &layer : bg.layers) {
 			if (layer.type == LobbyData::LAYERTYPE_IMAGE) {
 				SokuLib::Vector2i tsize = {
@@ -1084,7 +1086,7 @@ int InLobbyMenu::onRender()
 					elevator.skin.sprite.draw();
 				}
 			}
-			for (auto &player : players) {
+			for (auto &player : this->_playersCopy) {
 				if (std::find(this->_insideElevator.begin(), this->_insideElevator.end(), player.id) == this->_insideElevator.end())
 					continue;
 				if (player.player.avatar < lobbyData->avatars.size()) {
@@ -1209,7 +1211,7 @@ int InLobbyMenu::onRender()
 				elevator.skin.sprite.draw();
 			}
 
-			for (auto &player : players) {
+			for (auto &player : this->_playersCopy) {
 				if (std::find(this->_insideElevator.begin(), this->_insideElevator.end(), player.id) != this->_insideElevator.end())
 					continue;
 				if (player.player.avatar < lobbyData->avatars.size()) {
@@ -1258,8 +1260,8 @@ int InLobbyMenu::onRender()
 
 		std::vector<std::tuple<float, float, unsigned>> lastTexts;
 
-		lastTexts.reserve(players.size());
-		for (auto &player : players) {
+		lastTexts.reserve(this->_playersCopy.size());
+		for (auto &player : this->_playersCopy) {
 			unsigned nb = 0;
 			auto &name = this->_extraPlayerData[player.id].name;
 			auto minPos = this->_translate.x + player.pos.x - name.getSize().x / 2.f;
@@ -1302,6 +1304,7 @@ int InLobbyMenu::onRender()
 
 void InLobbyMenu::_unhook()
 {
+	std::lock_guard<std::mutex> functionMutexGuard(this->_connection->functionMutex);
 	this->_connection->onConnectRequest = this->onConnectRequest;
 	this->_connection->onError = this->onError;
 	this->_connection->onImpMsg = this->onImpMsg;

--- a/src/SokuMod/InLobbyMenu.hpp
+++ b/src/SokuMod/InLobbyMenu.hpp
@@ -88,6 +88,7 @@ private:
 	SokuLib::MenuConnect *_parent;
 	bool _wasConnected = false;
 	bool _disconnected = false;
+	std::vector<Player> _playersCopy;
 	unsigned _chatTimer = 0;
 	unsigned _chatOffset = 0;
 	uint8_t _background = 0;

--- a/src/SokuMod/LobbyMenu.cpp
+++ b/src/SokuMod/LobbyMenu.cpp
@@ -206,6 +206,8 @@ LobbyMenu::~LobbyMenu()
 		this->_masterThread.join();
 	if (this->_connectThread.joinable())
 		this->_connectThread.join();
+	std::lock_guard<std::mutex> connectionsMutexGuard(this->_connectionsMutex);
+	this->_connections.clear();
 }
 
 void LobbyMenu::_netLoop()

--- a/src/SokuMod/LobbyMenu.cpp
+++ b/src/SokuMod/LobbyMenu.cpp
@@ -863,6 +863,8 @@ void LobbyMenu::_connectLoop()
 					runOnUI(fct);
 
 					connection->c = std::make_shared<Connection>(connection->ip, connection->port, this->_loadedSettings);
+
+					std::lock_guard<std::mutex> functionMutexGuard(connection->c->functionMutex);
 					connection->c->onError = [weak, this](const std::string &msg) {
 						auto fct = [weak, msg, this]{
 							auto c = weak.lock();


### PR DESCRIPTION
This PR use the following locking conventions:

- lock acquisition order: `Connection::_meMutex`, `Connection::_playerMutex`, `Connection::_functionMutex`, `EnterCriticalSection((LPCRITICAL_SECTION)0x8a0e14)`. (`(LPCRITICAL_SECTION)0x8a0e14` has been locked in Soku code when `onRender` is called, so don't lock these three mutexes in `onRender`.)
- when `Connection::on`* functions are called, these three mutexes have been locked for them.