### PR TITLE
Clean old chat messages

### DIFF
--- a/src/SokuMod/InLobbyMenu.hpp
+++ b/src/SokuMod/InLobbyMenu.hpp
@@ -108,6 +108,7 @@ private:
 	SokuLib::DrawUtils::Sprite _loadingGear;
 	SokuLib::DrawUtils::Sprite _battleStatus[3];
 	std::list<Message> _chatMessages;
+	std::mutex _chatMessagesMutex;
 	std::map<uint32_t, PlayerData> _extraPlayerData;
 	std::wstring _buffer;
 	std::vector<ArcadeMachine> _machines;

--- a/src/SokuMod/SokuLobbies.ini
+++ b/src/SokuMod/SokuLobbies.ini
@@ -58,3 +58,6 @@ JoinInterval=1
 ; If the lobby server IP got from MainServer and its your global IP are the same, it will redirect.
 ; Default: localhost
 RedirectIp=localhost
+
+; Set the maximum number of chat messages kept on memory to be reviewed.
+MaxChatMessages=100

--- a/src/SokuMod/data.hpp
+++ b/src/SokuMod/data.hpp
@@ -25,6 +25,7 @@ extern char modVersion[16];
 extern char *wineVersion;
 extern unsigned lobbyJoinTries;
 extern unsigned lobbyJoinInterval;
+extern unsigned maxChatMessages;
 extern unsigned hostPref;
 extern unsigned chatKey;
 extern unsigned short servPort;

--- a/src/SokuMod/main.cpp
+++ b/src/SokuMod/main.cpp
@@ -61,6 +61,7 @@ unsigned hostPref;
 unsigned chatKey;
 unsigned lobbyJoinTries;
 unsigned lobbyJoinInterval;
+unsigned maxChatMessages;
 unsigned short servPort;
 unsigned short hostPort;
 bool hasSoku2 = false;
@@ -1104,6 +1105,7 @@ extern "C" __declspec(dllexport) bool Initialize(HMODULE hMyModule, HMODULE hPar
 	chatKey = GetPrivateProfileIntW(L"Lobby", L"ChatKey", VK_RETURN, profilePath);
 	lobbyJoinTries = GetPrivateProfileIntW(L"Lobby", L"JoinTries", 15, profilePath);
 	lobbyJoinInterval = GetPrivateProfileIntW(L"Lobby", L"JoinInterval", 1, profilePath);
+	maxChatMessages = GetPrivateProfileIntW(L"Lobby", L"MaxChatMessages", 100, profilePath);
 	lobbyJoinTries += !lobbyJoinTries;
 	lobbyJoinInterval += !lobbyJoinInterval;
 


### PR DESCRIPTION
It has been reported by CN community that the game will run out of memory after the user keeps in a lobby with a large amount of messages received. This commit, of which the idea was from @Tstar00, removes too old messages to avoid them from running out of the available 2GB memory space.